### PR TITLE
Update Equipool Stratums

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -49,6 +49,27 @@
 	  ]
 	},
 	{
+		"poolName": "Equipool Asia",
+		"url": "https://equipool.1ds.us/getting_started",
+		"searchStrings": [
+			"Equipool Asia"
+		]
+	},
+	{
+		"poolName": "Equipool Europe",
+		"url": "https://equipool.1ds.us/getting_started",
+		"searchStrings": [
+			"Equipool Europe"
+		]
+	},
+	{
+		"poolName": "Equipool North America",
+		"url": "https://equipool.1ds.us/getting_started",
+		"searchStrings": [
+			"Equipool North America"
+		]
+	},
+	{
 		"poolName": "Windfall mining",
 		"url": "https://www.windfallmining.com/",
 		"searchStrings": [


### PR DESCRIPTION
Equipool now reports each stratum separately. This commit enables the explorer to list each stratum's hex.

As mentioned in https://github.com/zelcash/insight-api-zelcash/pull/7, I completely understand if this is not acceptable since you're using addresses for the search.